### PR TITLE
Use Alpine Linux for Tiny Images

### DIFF
--- a/1.0.0-alpha10/Dockerfile
+++ b/1.0.0-alpha10/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Rob Loach <robloach@gmail.com>
 ENV COMPOSER_VERSION 1.0.0-alpha10
 
 # Install Composer
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --version=${COMPOSER_VERSION}
+RUN php -r "readfile('https://getcomposer.org/installer');" | php -- --install-dir=/usr/local/bin --filename=composer --version=${COMPOSER_VERSION}
 
 # Display version information
 RUN composer --version

--- a/1.0.0-alpha10/Dockerfile
+++ b/1.0.0-alpha10/Dockerfile
@@ -5,7 +5,8 @@ MAINTAINER Rob Loach <robloach@gmail.com>
 ENV COMPOSER_VERSION 1.0.0-alpha10
 
 # Install Composer
-RUN php -r "readfile('https://getcomposer.org/installer');" | php -- --install-dir=/usr/local/bin --filename=composer --version=${COMPOSER_VERSION}
+RUN php -r "readfile('https://getcomposer.org/installer');" \
+  | php -- --install-dir=/usr/local/bin --filename=composer --version=${COMPOSER_VERSION}
 
 # Display version information
-RUN composer --version
+RUN ["composer", "--version"]

--- a/1.0.0-alpha8/Dockerfile
+++ b/1.0.0-alpha8/Dockerfile
@@ -5,7 +5,8 @@ MAINTAINER Rob Loach <robloach@gmail.com>
 ENV COMPOSER_VERSION 1.0.0-alpha8
 
 # Install Composer
-RUN php -r "readfile('https://getcomposer.org/installer');" | php -- --install-dir=/usr/local/bin --filename=composer --version=${COMPOSER_VERSION}
+RUN php -r "readfile('https://getcomposer.org/installer');" \
+  | php -- --install-dir=/usr/local/bin --filename=composer --version=${COMPOSER_VERSION}
 
 # Display version information
-RUN composer --version
+RUN ["composer", "--version"]

--- a/1.0.0-alpha8/Dockerfile
+++ b/1.0.0-alpha8/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Rob Loach <robloach@gmail.com>
 ENV COMPOSER_VERSION 1.0.0-alpha8
 
 # Install Composer
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --version=${COMPOSER_VERSION}
+RUN php -r "readfile('https://getcomposer.org/installer');" | php -- --install-dir=/usr/local/bin --filename=composer --version=${COMPOSER_VERSION}
 
 # Display version information
 RUN composer --version

--- a/1.0.0-alpha9/Dockerfile
+++ b/1.0.0-alpha9/Dockerfile
@@ -5,7 +5,8 @@ MAINTAINER Rob Loach <robloach@gmail.com>
 ENV COMPOSER_VERSION 1.0.0-alpha9
 
 # Install Composer
-RUN php -r "readfile('https://getcomposer.org/installer');" | php -- --install-dir=/usr/local/bin --filename=composer --version=${COMPOSER_VERSION}
+RUN php -r "readfile('https://getcomposer.org/installer');" \
+  | php -- --install-dir=/usr/local/bin --filename=composer --version=${COMPOSER_VERSION}
 
 # Display version information
-RUN composer --version
+RUN ["composer", "--version"]

--- a/1.0.0-alpha9/Dockerfile
+++ b/1.0.0-alpha9/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Rob Loach <robloach@gmail.com>
 ENV COMPOSER_VERSION 1.0.0-alpha9
 
 # Install Composer
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --version=${COMPOSER_VERSION}
+RUN php -r "readfile('https://getcomposer.org/installer');" | php -- --install-dir=/usr/local/bin --filename=composer --version=${COMPOSER_VERSION}
 
 # Display version information
 RUN composer --version

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -4,17 +4,10 @@ FROM alpine:3.1
 MAINTAINER Rob Loach <robloach@gmail.com>
 
 # Packages
-RUN apk --update add ca-certificates \
-                     php-bz2 \
-                     php-gd \
-                     php-json \
-                     php-mcrypt \
-                     php-openssl \
-                     php-phar \
-                     php-zip
+RUN ["apk", "--update", "add", "ca-certificates", "git", "mercurial", "php-bz2", "php-gd", "php-json", "php-mcrypt", "php-openssl", "php-pear", "php-phar", "php-zip", "subversion", "unrar"]
 
-# Display PHP version
-RUN php --version
+# Display PHP info
+RUN ["php", "-i"]
 
 # Set up the application directory
 VOLUME ["/app"]

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,34 +1,17 @@
 # Composer Docker Container
 # Base Dockerfile: composer/base
-FROM php:5.6-cli
+FROM alpine:3.1
 MAINTAINER Rob Loach <robloach@gmail.com>
 
 # Packages
-RUN apt-get update && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    libfreetype6-dev \
-    libjpeg62-turbo-dev \
-    libmcrypt-dev \
-    libpng12-dev \
-    libbz2-dev \
-    php-pear \
-    curl \
-    git \
-  && rm -r /var/lib/apt/lists/*
-
-# PHP Extensions
-RUN docker-php-ext-install mcrypt zip bz2 mbstring \
-  && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-  && docker-php-ext-install gd
-
-# Memory Limit
-RUN echo "memory_limit=1024M" > /usr/local/etc/php/conf.d/memory-limit.ini
-
-# Time Zone
-RUN echo "date.timezone=${PHP_TIMEZONE:-UTC}" > /etc/php5/cli/conf.d/date_timezone.ini
-
-# Environmental Variables
-ENV COMPOSER_HOME /root/composer
+RUN apk --update add ca-certificates \
+                     php-bz2 \
+                     php-gd \
+                     php-json \
+                     php-mcrypt \
+                     php-openssl \
+                     php-phar \
+                     php-zip
 
 # Display PHP version
 RUN php --version

--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -5,7 +5,8 @@ MAINTAINER Rob Loach <robloach@gmail.com>
 ENV COMPOSER_VERSION master
 
 # Install Composer
-RUN php -r "readfile('https://getcomposer.org/installer');" | php -- --install-dir=/usr/local/bin --filename=composer
+RUN php -r "readfile('https://getcomposer.org/installer');" \
+  | php -- --install-dir=/usr/local/bin --filename=composer
 
 # Display version information
-RUN composer --version
+RUN ["composer", "--version"]

--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Rob Loach <robloach@gmail.com>
 ENV COMPOSER_VERSION master
 
 # Install Composer
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+RUN php -r "readfile('https://getcomposer.org/installer');" | php -- --install-dir=/usr/local/bin --filename=composer
 
 # Display version information
 RUN composer --version


### PR DESCRIPTION
I saw there was a PR for using Debian instead of the PHP official images. There's another official image that I think is very useful for building good base images: [Alpine](https://registry.hub.docker.com/_/alpine/). For comparison:

```
# Current images
$ docker images | grep composer/composer
composer/composer                                   base                eb1df2aafe51        3 weeks ago         521.9 MB
composer/composer                                   1.0.0-alpha8        aa4d3eabda20        3 weeks ago         522.9 MB
composer/composer                                   1.0.0-alpha10       11b069d27b51        3 weeks ago         523 MB
composer/composer                                   latest              b87b6a34ca39        3 weeks ago         523 MB
composer/composer                                   1.0.0-alpha9        58acc7adbc48        3 weeks ago         523 MB

# Alpine images
$ docker images | grep composer/composer
composer/composer                                   1.0.0-alpha8        5b8d2ca4148a        14 minutes ago      22.57 MB
composer/composer                                   1.0.0-alpha9        fc5edf265f13        14 minutes ago      22.64 MB
composer/composer                                   1.0.0-alpha10       e858b3a69ef1        14 minutes ago      22.68 MB
composer/composer                                   latest              e9eb902514ea        17 minutes ago      22.72 MB
composer/composer                                   base                2bf3879927f9        17 minutes ago      21.6 MB
```
```