### PR TITLE
Wrapper for Safely Ignoring Platform Deps

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -38,5 +38,6 @@ VOLUME ["/app"]
 WORKDIR /app
 
 # Set up the command arguments
+COPY wrapcomposer /usr/local/bin/wrapcomposer
 CMD ["-"]
-ENTRYPOINT ["composer", "--ansi"]
+ENTRYPOINT ["wrapcomposer", "--ansi"]

--- a/base/wrapcomposer
+++ b/base/wrapcomposer
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+##
+# Make --ignore-platform-reqs default for
+# `install`, `remove` and `update`
+# but omit for other commands
+
+for arg; do
+    case "$arg" in
+        install|remove|update) set -- --ignore-platform-reqs "$@";;
+        *) :;;
+    esac
+done
+
+exec composer "$@"


### PR DESCRIPTION
This addresses #13 with a wrapper script. If the given command has `install`, `remove` or `update`, the `--ignore-platform-reqs` option is appended to the composer command. Otherwise, no change.
