### PR TITLE
Fix date.timezone config being created in the wrong directory

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -25,7 +25,7 @@ RUN docker-php-ext-install mcrypt zip bz2 mbstring \
 RUN echo "memory_limit=1024M" > /usr/local/etc/php/conf.d/memory-limit.ini
 
 # Time Zone
-RUN echo "date.timezone=${PHP_TIMEZONE:-UTC}" > /etc/php5/cli/conf.d/date_timezone.ini
+RUN echo "date.timezone=${PHP_TIMEZONE:-UTC}" > /usr/local/etc/php/conf.d/date_timezone.ini
 
 # Environmental Variables
 ENV COMPOSER_HOME /root/composer


### PR DESCRIPTION
The date.timezone setting was being created in /etc/php rather than /usr/local/etc/php, and therefore not being picked up.

To reproduce:

```
# run with Bash entrypoint, delete after
docker run -it --rm --entrypoint=/bin/bash composer/composer

# show PHP timezone setting
php -r 'echo date_default_timezone_get() . "\n";'
```

The above gives this output if using the latest version of composer/composer:

```
Warning: date_default_timezone_get(): It is not safe to rely on the system's timezone settings. You are *required* to use the date.timezone setting or the date_default_timezone_set() function. In case you used any of those methods and you are still getting this warning, you most likely misspelled the timezone identifier. We selected the timezone 'UTC' for now, but please set date.timezone to select your timezone. in Command line code on line 1
UTC
```

After building the base and master images locally, the above commands just give this output:

```
UTC
```

I noticed this when building a Symfony 2 application; it has a strict check on the timezone setting.