### PR TITLE
Rely on PHP_INI_DIR environment variable

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -22,10 +22,10 @@ RUN docker-php-ext-install mcrypt zip bz2 mbstring \
   && docker-php-ext-install gd
 
 # Memory Limit
-RUN echo "memory_limit=1024M" > /usr/local/etc/php/conf.d/memory-limit.ini
+RUN echo "memory_limit=1024M" > $PHP_INI_DIR/conf.d/memory-limit.ini
 
 # Time Zone
-RUN echo "date.timezone=${PHP_TIMEZONE:-UTC}" > /usr/local/etc/php/conf.d/date_timezone.ini
+RUN echo "date.timezone=${PHP_TIMEZONE:-UTC}" > $PHP_INI_DIR/conf.d/date_timezone.ini
 
 # Environmental Variables
 ENV COMPOSER_HOME /root/composer


### PR DESCRIPTION
Fixes #22 

The php:5.6-cli docker container rely on an environment variable to set the ini directory.