### PR TITLE
Add composer-changelogs plugin

### DIFF
--- a/1.0.0-alpha10/Dockerfile
+++ b/1.0.0-alpha10/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Rob Loach <robloach@gmail.com>
 ENV COMPOSER_VERSION 1.0.0-alpha10
 
 # Install Composer
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --version=${COMPOSER_VERSION}
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --version=${COMPOSER_VERSION} && composer global require "pyrech/composer-changelogs"
 
 # Display version information
 RUN composer --version

--- a/1.0.0-alpha8/Dockerfile
+++ b/1.0.0-alpha8/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Rob Loach <robloach@gmail.com>
 ENV COMPOSER_VERSION 1.0.0-alpha8
 
 # Install Composer
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --version=${COMPOSER_VERSION}
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --version=${COMPOSER_VERSION} && composer global require "pyrech/composer-changelogs"
 
 # Display version information
 RUN composer --version

--- a/1.0.0-alpha9/Dockerfile
+++ b/1.0.0-alpha9/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Rob Loach <robloach@gmail.com>
 ENV COMPOSER_VERSION 1.0.0-alpha9
 
 # Install Composer
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --version=${COMPOSER_VERSION}
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --version=${COMPOSER_VERSION} && composer global require "pyrech/composer-changelogs"
 
 # Display version information
 RUN composer --version

--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Rob Loach <robloach@gmail.com>
 ENV COMPOSER_VERSION master
 
 # Install Composer
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && composer global require "pyrech/composer-changelogs"
 
 # Display version information
 RUN composer --version


### PR DESCRIPTION
There is a plugin for composer that print a nice summary of update packages at the end of a composer update command with links to release and diffs : https://github.com/pyrech/composer-changelogs

Is that something that could be integrated in docker-compose ?
