### PR TITLE
Update to PHP 7

### DIFF
--- a/1.0.0-alpha11/Dockerfile
+++ b/1.0.0-alpha11/Dockerfile
@@ -1,5 +1,5 @@
 # Composer Docker Container
-FROM composer/composer:base
+FROM composer/composer:php7-base
 MAINTAINER Rob Loach <robloach@gmail.com>
 
 ENV COMPOSER_VERSION 1.0.0-alpha11

--- a/1.0.0-alpha11/Dockerfile
+++ b/1.0.0-alpha11/Dockerfile
@@ -1,5 +1,5 @@
 # Composer Docker Container
-FROM composer/composer:php7-base
+FROM composer/composer:base
 MAINTAINER Rob Loach <robloach@gmail.com>
 
 ENV COMPOSER_VERSION 1.0.0-alpha11

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   * [`1.0.0-alpha10`](https://github.com/composer/composer/blob/1.0.0-alpha10/CHANGELOG.md)
   * [`1.0.0-alpha9`](https://github.com/composer/composer/blob/1.0.0-alpha9/CHANGELOG.md)
   * [`1.0.0-alpha8`](https://github.com/composer/composer/blob/1.0.0-alpha8/CHANGELOG.md)
-* [PHP](http://php.net) [5.6](http://php.net/ChangeLog-5.php)
+* [PHP](http://php.net) [7](http://php.net/ChangeLog-7.php)
 
 ## Installation / Usage
 

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,6 +1,6 @@
 # Composer Docker Container
 # Base Dockerfile: composer/base
-FROM php:5.6-cli
+FROM php:7-cli
 MAINTAINER Rob Loach <robloach@gmail.com>
 
 # Packages


### PR DESCRIPTION
References https://github.com/RobLoach/docker-composer/issues/29 . cc @agiuliano 

At time of writing, the [PHP Docker library](https://hub.docker.com/r/library/php/) is at RC8. We could consider merging once stable is out.