### PR TITLE
Add global binary directory to path

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -33,7 +33,7 @@ RUN echo "date.timezone=${PHP_TIMEZONE:-UTC}" > $PHP_INI_DIR/conf.d/date_timezon
 ENV COMPOSER_HOME /root/composer
 
 # Add global binary directory to path
-ENV PATH /root/composer/vendor/bin:$PATH
+ENV PATH $COMPOSER_HOME/vendor/bin:$PATH
 
 # Display PHP version
 RUN php --version

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -32,6 +32,9 @@ RUN echo "date.timezone=${PHP_TIMEZONE:-UTC}" > $PHP_INI_DIR/conf.d/date_timezon
 # Environmental Variables
 ENV COMPOSER_HOME /root/composer
 
+# Add global binary directory to path
+ENV PATH /root/composer/vendor/bin:$PATH
+
 # Display PHP version
 RUN php --version
 


### PR DESCRIPTION
This allows Dockerfiles extending from this one to use `composer global require` and have subsequently installed binaries available on `$PATH`.

This is useful for Composer packages such as `phpunit/phpunit`, `phpmd/phpmd`, `deployer/deployer` or anything else that you might want installed globally, or packaged into a Docker container.

Example `Dockerfile`:

```Dockerfile
FROM composer/composer

RUN composer global require apigen/apigen

ENTRYPOINT ["apigen"]
CMD ["--version"]
```

Before this patch:

```sh-session
$ docker run -it --rm apigen/apigen
exec: "apigen": executable file not found in $PATH
Error response from daemon: Container command not found or does not exist.
```

After this patch:

```sh-session
$ docker run -it --rm apigen/apigen
ApiGen version 4.1.0
```