### PR TITLE
Alpine support for composer/composer (PHP7)

### DIFF
--- a/1.0.0/alpine/Dockerfile
+++ b/1.0.0/alpine/Dockerfile
@@ -1,0 +1,11 @@
+# Composer Docker Container
+FROM composer/composer:base-alpine
+MAINTAINER Rob Loach <robloach@gmail.com>
+
+ENV COMPOSER_VERSION 1.0.0
+
+# Install Composer
+RUN php /tmp/composer-setup.php --no-ansi --install-dir=/usr/local/bin --filename=composer --version=${COMPOSER_VERSION} && rm -rf /tmp/composer-setup.php
+
+# Display version information.
+RUN composer --version

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,12 @@ build:
 	docker build -t composer/composer:1.0.0-alpha10 1.0.0-alpha10
 	docker build -t composer/composer:1.0.0-alpha9 1.0.0-alpha9
 	docker build -t composer/composer:1.0.0-alpha8 1.0.0-alpha8
+	docker build -t composer/composer:base-alpine base/alpine
+	docker build -t composer/composer-alpine 1.0.0/alpine
+	docker build -t composer/composer:1-alpine 1.0.0/alpine
+	docker build -t composer/composer:1.0-alpine 1.0.0/alpine
+	docker build -t composer/composer:1.0.0-alpine 1.0.0/alpine
+	docker build -t composer/composer:master-alpine master/alpine
 
 version:
 	@echo -n "composer/composer\t\t"
@@ -34,6 +40,12 @@ version:
 	@docker run composer/composer:1.0.0-alpha9 --version --no-ansi
 	@echo -n "composer/composer:1.0.0-alpha8\t"
 	@docker run composer/composer:1.0.0-alpha8 --version --no-ansi
+	@echo -n "composer/composer-alpine\t\t"
+	@docker run composer/composer-alpine --version --no-ansi
+	@echo -n "composer/composer:master-alpine\t"
+	@docker run composer/composer:master-alpine --version --no-ansi
+	@echo -n "composer/composer:1.0.0-alpine\t\t"
+	@docker run composer/composer:1.0.0-alpine --version --no-ansi
 
 test:
 	@make version

--- a/base/alpine/Dockerfile
+++ b/base/alpine/Dockerfile
@@ -35,11 +35,6 @@ RUN echo "memory_limit=-1" > $PHP_INI_DIR/conf.d/memory-limit.ini
 # Time Zone
 RUN echo "date.timezone=${PHP_TIMEZONE:-UTC}" > $PHP_INI_DIR/conf.d/date_timezone.ini
 
-# Disable Populating Raw POST Data
-# Not needed when moving to PHP 7.
-# http://php.net/manual/en/ini.core.php#ini.always-populate-raw-post-data
-RUN echo "always_populate_raw_post_data=-1" > $PHP_INI_DIR/conf.d/always_populate_raw_post_data.ini
-
 # Register the COMPOSER_HOME environment variable
 ENV COMPOSER_HOME /composer
 

--- a/base/alpine/Dockerfile
+++ b/base/alpine/Dockerfile
@@ -8,7 +8,6 @@ RUN apk --update add \
     autoconf \
     build-base \
     curl \
-    gcc \
     git \
     subversion \
     freetype-dev \

--- a/base/alpine/Dockerfile
+++ b/base/alpine/Dockerfile
@@ -1,0 +1,64 @@
+# Composer Docker Container
+# Base Dockerfile: composer/base-alpine
+FROM php:7.0-alpine
+MAINTAINER Rob Loach <robloach@gmail.com>
+
+# Packages
+RUN apk --update add \
+    autoconf \
+    build-base \
+    curl \
+    gcc \
+    git \
+    subversion \
+    freetype-dev \
+    libjpeg-turbo-dev \
+    libmcrypt-dev \
+    libpng-dev \
+    libbz2 \
+    libstdc++ \
+    libxslt-dev \
+    openldap-dev \
+    make \
+    php-pear \
+    unzip && \
+    docker-php-ext-install mcrypt zip bz2 mbstring xsl && \
+    docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && \
+    docker-php-ext-install gd && \
+    docker-php-ext-configure ldap --with-libdir=lib/ && \
+    docker-php-ext-install ldap && \
+    apk del build-base && \
+    rm -rf /var/cache/apk/*
+
+# Memory Limit
+RUN echo "memory_limit=-1" > $PHP_INI_DIR/conf.d/memory-limit.ini
+
+# Time Zone
+RUN echo "date.timezone=${PHP_TIMEZONE:-UTC}" > $PHP_INI_DIR/conf.d/date_timezone.ini
+
+# Disable Populating Raw POST Data
+# Not needed when moving to PHP 7.
+# http://php.net/manual/en/ini.core.php#ini.always-populate-raw-post-data
+RUN echo "always_populate_raw_post_data=-1" > $PHP_INI_DIR/conf.d/always_populate_raw_post_data.ini
+
+# Register the COMPOSER_HOME environment variable
+ENV COMPOSER_HOME /composer
+
+# Add global binary directory to PATH and make sure to re-export it
+ENV PATH /composer/vendor/bin:$PATH
+
+# Allow Composer to be run as root
+ENV COMPOSER_ALLOW_SUPERUSER 1
+
+# Setup the Composer installer
+ENV COMPOSER_INSTALLER_SHA384 "7228c001f88bee97506740ef0888240bd8a760b046ee16db8f4095c0d8d525f2367663f22a46b48d072c816e7fe19959"
+RUN php -r "readfile('https://getcomposer.org/installer');" > /tmp/composer-setup.php \
+  && php -r "if (hash('SHA384', file_get_contents('/tmp/composer-setup.php')) !== '${COMPOSER_INSTALLER_SHA384}') { unlink('/tmp/composer-setup.php'); echo 'Invalid installer' . PHP_EOL; exit(1); }"
+
+# Set up the volumes and working directory
+VOLUME ["/app"]
+WORKDIR /app
+
+# Set up the command arguments
+CMD ["-"]
+ENTRYPOINT ["composer", "--ansi"]

--- a/master/alpine/Dockerfile
+++ b/master/alpine/Dockerfile
@@ -1,0 +1,11 @@
+# Composer Docker Container
+FROM composer/composer:base-alpine
+MAINTAINER Rob Loach <robloach@gmail.com>
+
+ENV COMPOSER_VERSION master
+
+# Install Composer
+RUN php /tmp/composer-setup.php --no-ansi --install-dir=/usr/local/bin --filename=composer --snapshot && rm -rf /tmp/composer-setup.php
+
+# Display version information
+RUN composer --version


### PR DESCRIPTION
Updated P.R. based off of php:7.0-alpine

php:7.0-alpine; 382.7 MB
composer:composer-alpine: 465.4 MB

Ref: https://github.com/RobLoach/docker-composer/pull/19

This one matches closely the other Dockerfiles and leveragers docker-php-ext to install addons instead of package manager. Talk about diferences between using source vs apk install is here: https://github.com/docker-library/php/pull/206

Eventually the parent image will be much smaller once  some build dependencies are removed during runtime here:

https://github.com/docker-library/php/pull/206
