### PR TITLE
Fixed php7-pear on base-alpine

### DIFF
--- a/base/alpine/Dockerfile
+++ b/base/alpine/Dockerfile
@@ -29,10 +29,8 @@ RUN apk --update add \
     apk del build-base && \
     rm -rf /var/cache/apk/*
 
-# PEAR tmp fix
-RUN echo "@testing http://dl-4.alpinelinux.org/alpine/edge/testing/" >> /etc/apk/repositories && \
-    apk add --update php7-pear@testing && \
-    rm -rf /var/cache/apk/*
+RUN echo "@edge http://dl-4.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
+    apk add -U --no-cache php7-pear@edge
 
 # Memory Limit
 RUN echo "memory_limit=-1" > $PHP_INI_DIR/conf.d/memory-limit.ini

--- a/base/alpine/Dockerfile
+++ b/base/alpine/Dockerfile
@@ -4,7 +4,7 @@ FROM php:7.0-alpine
 MAINTAINER Rob Loach <robloach@gmail.com>
 
 # Packages
-RUN apk --update add \
+RUN apk --update --no-cache add \
     autoconf \
     build-base \
     curl \
@@ -26,8 +26,7 @@ RUN apk --update add \
     docker-php-ext-install gd && \
     docker-php-ext-configure ldap --with-libdir=lib/ && \
     docker-php-ext-install ldap && \
-    apk del build-base && \
-    rm -rf /var/cache/apk/*
+    apk del build-base
 
 RUN echo "@edge http://dl-4.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
     apk add -U --no-cache php7-pear@edge


### PR DESCRIPTION
The package `php7-pear` has moved from testing to community.

I applied some tweaks as well on the `apk` commands : 
- `apk --update` doesn't  update the package index. Replaced it with `-U`` which does.
- consider using `--no-cache` instead of `rm -rf /var/cache/apk/*``. Same behavior but is built-in Alpine.

> `-U` could be replaced with `--update-cache`, see [alpine's wiki](https://wiki.alpinelinux.org/wiki/Enable_Community_Repository).

Doubled check (and tested) the changes, everything should be fine.
