### PR TITLE
Fix #94: add openssh-client to Alpine-based images

### DIFF
--- a/base/alpine/Dockerfile
+++ b/base/alpine/Dockerfile
@@ -18,6 +18,7 @@ RUN apk --update add \
     libstdc++ \
     libxslt-dev \
     openldap-dev \
+    openssh-client \
     make \
     unzip \
     wget && \

--- a/base/php5-alpine/Dockerfile
+++ b/base/php5-alpine/Dockerfile
@@ -18,6 +18,7 @@ RUN apk --update add \
     libstdc++ \
     libxslt-dev \
     openldap-dev \
+    openssh-client \
     make \
     php5-pear \
     unzip \


### PR DESCRIPTION
It is impossible to install dependencies from git repositories using the Alpine-based versions because ssh is missing.

Example:

```
docker run --rm -v $(pwd):/app -v ~/.ssh:/root/.ssh composer/composer:alpine outdated
```

produces a RuntimeException:

```
  [RuntimeException]                                                                                                               
  Failed to execute git clone --mirror 'git@bitbucket.org:repo/name.git' '/composer/cache/vcs/git-bitbucket.org-repo-name.git/'  
  Cloning into bare repository '/composer/cache/vcs/git-bitbucket.org-repo-name.git'...                                           
  error: cannot run ssh: No such file or directory                                                                                 
  fatal: unable to fork
```

This commit fixes that by adding the openssh-client package to the Alpine-based Dockerfiles.