### PR TITLE
Use a shell script as entry point to avoid problems with “sh” commands

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -57,6 +57,8 @@ RUN curl -o /tmp/composer-setup.php https://getcomposer.org/installer \
 VOLUME ["/app"]
 WORKDIR /app
 
+COPY docker-entrypoint.sh /usr/local/bin/
+
 # Set up the command arguments
-CMD ["-"]
-ENTRYPOINT ["composer", "--ansi"]
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["--ansi"]

--- a/base/alpine/Dockerfile
+++ b/base/alpine/Dockerfile
@@ -55,6 +55,8 @@ RUN curl -o /tmp/composer-setup.php https://getcomposer.org/installer \
 VOLUME ["/app"]
 WORKDIR /app
 
+COPY docker-entrypoint.sh /usr/local/bin/
+
 # Set up the command arguments
-CMD ["-"]
-ENTRYPOINT ["composer", "--ansi"]
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["--ansi"]

--- a/base/alpine/docker-entrypoint.sh
+++ b/base/alpine/docker-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- composer "$@"
+fi
+
+# if our command is a valid composer subcommand, let's invoke it through composer instead
+# (this allows for "docker run composer/composer update", etc)
+if [ "$1" != "sh" ] && composer "$1" --help > /dev/null 2>&1 ]; then
+	set -- composer "$@"
+fi
+
+exec "$@"

--- a/base/docker-entrypoint.sh
+++ b/base/docker-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- composer "$@"
+fi
+
+# if our command is a valid composer subcommand, let's invoke it through composer instead
+# (this allows for "docker run composer/composer update", etc)
+if [ "$1" != "sh" ] && composer "$1" --help > /dev/null 2>&1 ]; then
+	set -- composer "$@"
+fi
+
+exec "$@"

--- a/base/php5-alpine/Dockerfile
+++ b/base/php5-alpine/Dockerfile
@@ -54,6 +54,8 @@ RUN curl -o /tmp/composer-setup.php https://getcomposer.org/installer \
 VOLUME ["/app"]
 WORKDIR /app
 
+COPY docker-entrypoint.sh /usr/local/bin/
+
 # Set up the command arguments
-CMD ["-"]
-ENTRYPOINT ["composer", "--ansi"]
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["--ansi"]

--- a/base/php5-alpine/docker-entrypoint.sh
+++ b/base/php5-alpine/docker-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- composer "$@"
+fi
+
+# if our command is a valid composer subcommand, let's invoke it through composer instead
+# (this allows for "docker run composer/composer update", etc)
+if [ "$1" != "sh" ] && composer "$1" --help > /dev/null 2>&1 ]; then
+	set -- composer "$@"
+fi
+
+exec "$@"

--- a/base/php5/Dockerfile
+++ b/base/php5/Dockerfile
@@ -57,6 +57,8 @@ RUN curl -o /tmp/composer-setup.php https://getcomposer.org/installer \
 VOLUME ["/app"]
 WORKDIR /app
 
+COPY docker-entrypoint.sh /usr/local/bin/
+
 # Set up the command arguments
-CMD ["-"]
-ENTRYPOINT ["composer", "--ansi"]
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["--ansi"]

--- a/base/php5/docker-entrypoint.sh
+++ b/base/php5/docker-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- composer "$@"
+fi
+
+# if our command is a valid composer subcommand, let's invoke it through composer instead
+# (this allows for "docker run composer/composer update", etc)
+if [ "$1" != "sh" ] && composer "$1" --help > /dev/null 2>&1 ]; then
+	set -- composer "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
ATM if you pass `sh -c somescript.sh` to the container as some CI tools do,
the command is passed to the entry point and is executed as
`composer —ansi sh -c somescript.sh`

To avoid this an docker-entrypoint script is used.

Resolves: #91